### PR TITLE
Enhance tests for assertions and string casting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4
 
 before_script:
     - travis_retry composer self-update
-    - travis_retry composer install --no-interaction --prefer-source --dev
+    - travis_retry composer install --no-interaction --prefer-source
 
 script:
     - vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/MonobankClient.php
+++ b/src/MonobankClient.php
@@ -90,7 +90,7 @@ class MonobankClient implements MonobankPublicDataClientInterface, MonobankPriva
     {
         $headers = [
             'Accept' => 'application/json',
-            'User-Agent' => sprintf('%s MonobankPHPClient/%s', $this->client->getConfig('headers')['User-Agent'], MONOBANK_CLIENT_VERSION),
+            'User-Agent' => sprintf('%s MonobankPHPClient/%s', $this->client->getConfig('headers')['User-Agent'] ?? '', MONOBANK_CLIENT_VERSION),
         ];
 
         if (null !== $token) {

--- a/tests/GetClientInfoTest.php
+++ b/tests/GetClientInfoTest.php
@@ -51,9 +51,9 @@ class GetClientInfoTest extends TestCase
 
         $result = $client->getClientInfo();
 
-        $this->assertTrue(is_array($result));
-        $this->assertTrue(is_array($result['accounts']));
-        $this->assertTrue(1 == count($result['accounts']));
+        $this->assertIsArray($result);
+        $this->assertIsArray($result['accounts']);
+        $this->assertCount(1, $result['accounts']);
         $this->assertEquals('Mono cat', $result['name']);
     }
 
@@ -147,7 +147,7 @@ class GetClientInfoTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/GetExchangeRatesTest.php
+++ b/tests/GetExchangeRatesTest.php
@@ -51,8 +51,8 @@ class GetExchangeRatesTest extends TestCase
 
         $result = $client->getExchangeRates();
 
-        $this->assertTrue(is_array($result));
-        $this->assertTrue(1 == count($result));
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
         $this->assertEquals(840, $result[0]['currencyCodeA']);
         $this->assertEquals(980, $result[0]['currencyCodeB']);
         $this->assertEquals(1552392228, $result[0]['date']);
@@ -148,7 +148,7 @@ class GetExchangeRatesTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/GetPersonalStatementTest.php
+++ b/tests/GetPersonalStatementTest.php
@@ -56,13 +56,13 @@ class GetPersonalStatementTest extends TestCase
         $client = new MonobankClient($httpClient, $token);
         $result = $client->getPersonalStatement(new PersonalStatementRequest(new DateTime(), new DateTime()));
 
-        $this->assertTrue(is_array($result));
-        $this->assertTrue(1 == count($result));
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
         $this->assertEquals('ZuHWzqkKGVo=', $result[0]['id']);
         $this->assertEquals(1554466347, $result[0]['time']);
         $this->assertEquals('Покупка щастя', $result[0]['description']);
         $this->assertEquals(7997, $result[0]['mcc']);
-        $this->assertEquals(false, $result[0]['hold']);
+        $this->assertFalse($result[0]['hold']);
         $this->assertEquals(-95000, $result[0]['amount']);
         $this->assertEquals(-95000, $result[0]['operationAmount']);
         $this->assertEquals(980, $result[0]['currencyCode']);
@@ -215,7 +215,7 @@ class GetPersonalStatementTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/ValueObject/AccountIDTest.php
+++ b/tests/ValueObject/AccountIDTest.php
@@ -22,7 +22,7 @@ class AccountIDTest extends TestCase
      */
     public function testSuccess(string $id)
     {
-        $this->assertEquals($id, strval(new AccountID($id)));
+        $this->assertEquals($id, (string) (new AccountID($id)));
     }
 
     /**

--- a/tests/ValueObject/TokenTest.php
+++ b/tests/ValueObject/TokenTest.php
@@ -22,7 +22,7 @@ class TokenTest extends TestCase
      */
     public function testSuccess(string $token)
     {
-        $this->assertEquals($token, strval(new Token($token)));
+        $this->assertEquals($token, (string) (new Token($token)));
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Removing `--dev` option because this option is deprecated. The deprecated message is as follows:
```
You are using the deprecated option "dev". Dev packages are installed by default now.
```

- Add `php-7.4` version during Travis CI build.
- The PHPUnit fixture about `setUp`  should be `protected function setUp(): void`.
- Using `assertIsArray` to expect value type is `array`.
- Using `assertCount` to expect value count is same as result.
- Using `string` casting type to replace `strval` function because this class of `__toString` method has been implemented.
- To fix `Trying to access array offset on value of type null` on `php-7.4` version,  it should use `$this->client->getConfig('headers')['User-Agent'] ?? ''` syntax to handle the value is null type. 