### PR TITLE
Improve equals assertion

### DIFF
--- a/tests/GetClientInfoTest.php
+++ b/tests/GetClientInfoTest.php
@@ -54,7 +54,7 @@ class GetClientInfoTest extends TestCase
         $this->assertIsArray($result);
         $this->assertIsArray($result['accounts']);
         $this->assertCount(1, $result['accounts']);
-        $this->assertEquals('Mono cat', $result['name']);
+        $this->assertSame('Mono cat', $result['name']);
     }
 
     /**

--- a/tests/GetExchangeRatesTest.php
+++ b/tests/GetExchangeRatesTest.php
@@ -53,12 +53,12 @@ class GetExchangeRatesTest extends TestCase
 
         $this->assertIsArray($result);
         $this->assertCount(1, $result);
-        $this->assertEquals(840, $result[0]['currencyCodeA']);
-        $this->assertEquals(980, $result[0]['currencyCodeB']);
-        $this->assertEquals(1552392228, $result[0]['date']);
-        $this->assertEquals(27, $result[0]['rateSell']);
-        $this->assertEquals(27.2, $result[0]['rateBuy']);
-        $this->assertEquals(27.1, $result[0]['rateCross']);
+        $this->assertSame(840, $result[0]['currencyCodeA']);
+        $this->assertSame(980, $result[0]['currencyCodeB']);
+        $this->assertSame(1552392228, $result[0]['date']);
+        $this->assertSame(27, $result[0]['rateSell']);
+        $this->assertSame(27.2, $result[0]['rateBuy']);
+        $this->assertSame(27.1, $result[0]['rateCross']);
     }
 
     /**

--- a/tests/GetPersonalStatementTest.php
+++ b/tests/GetPersonalStatementTest.php
@@ -58,17 +58,17 @@ class GetPersonalStatementTest extends TestCase
 
         $this->assertIsArray($result);
         $this->assertCount(1, $result);
-        $this->assertEquals('ZuHWzqkKGVo=', $result[0]['id']);
-        $this->assertEquals(1554466347, $result[0]['time']);
-        $this->assertEquals('Покупка щастя', $result[0]['description']);
-        $this->assertEquals(7997, $result[0]['mcc']);
+        $this->assertSame('ZuHWzqkKGVo=', $result[0]['id']);
+        $this->assertSame(1554466347, $result[0]['time']);
+        $this->assertSame('Покупка щастя', $result[0]['description']);
+        $this->assertSame(7997, $result[0]['mcc']);
         $this->assertFalse($result[0]['hold']);
-        $this->assertEquals(-95000, $result[0]['amount']);
-        $this->assertEquals(-95000, $result[0]['operationAmount']);
-        $this->assertEquals(980, $result[0]['currencyCode']);
-        $this->assertEquals(0, $result[0]['commissionRate']);
-        $this->assertEquals(19000, $result[0]['cashbackAmount']);
-        $this->assertEquals(10050000, $result[0]['balance']);
+        $this->assertSame(-95000, $result[0]['amount']);
+        $this->assertSame(-95000, $result[0]['operationAmount']);
+        $this->assertSame(980, $result[0]['currencyCode']);
+        $this->assertSame(0, $result[0]['commissionRate']);
+        $this->assertSame(19000, $result[0]['cashbackAmount']);
+        $this->assertSame(10050000, $result[0]['balance']);
     }
 
     /**

--- a/tests/ValueObject/AccountIDTest.php
+++ b/tests/ValueObject/AccountIDTest.php
@@ -22,7 +22,7 @@ class AccountIDTest extends TestCase
      */
     public function testSuccess(string $id)
     {
-        $this->assertEquals($id, (string) (new AccountID($id)));
+        $this->assertSame($id, (string) (new AccountID($id)));
     }
 
     /**

--- a/tests/ValueObject/TokenTest.php
+++ b/tests/ValueObject/TokenTest.php
@@ -22,7 +22,7 @@ class TokenTest extends TestCase
      */
     public function testSuccess(string $token)
     {
-        $this->assertEquals($token, (string) (new Token($token)));
+        $this->assertSame($token, (string) (new Token($token)));
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make equals assertion strict.